### PR TITLE
Pass deps to cc_library target in gz_configure_file

### DIFF
--- a/gazebo/private/gz_configure_file.bzl
+++ b/gazebo/private/gz_configure_file.bzl
@@ -57,6 +57,7 @@ def gz_configure_file(
         defines = None,
         undefines = None,
         package_xml = None,
+        deps = [],
         **kwargs):
     """
     Expand templates in a file using project variables
@@ -68,6 +69,7 @@ def gz_configure_file(
       defines: Variables to define
       undefines: Variables to unset
       package_xml: Package.xml file to read name and version from
+      deps: Deps to be forwarded to the cc_library target wrapping the header
       **kwargs: Additional keyword arguments
     """
     if not out:
@@ -91,4 +93,5 @@ def gz_configure_file(
         name = name,
         hdrs = [out],
         includes = ["include"],
+        deps = deps,
     )


### PR DESCRIPTION
Some *config.hh.in files in gz projects have extensive dependencies embedded in them (e.g. https://github.com/gazebosim/gz-fuel-tools/blob/gz-fuel-tools10/test/test_config.hh.in). So the `cc_library` target fails to compile with [`parse_headers`](https://bazel.build/docs/bazel-and-cpp#toolchain-features) enabled.

The fix is to allow passing a `deps` array to the `cc_library` target.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
