### PR TITLE
Add helper rule to generate lumped header file

### DIFF
--- a/gazebo/headers.bzl
+++ b/gazebo/headers.bzl
@@ -22,7 +22,12 @@ load(
     "//gazebo/private:gz_export_header.bzl",
     _gz_export_header = "gz_export_header",
 )
+load(
+    "//gazebo/private:gz_include_header.bzl",
+    _gz_include_header = "gz_include_header",
+)
 
 gz_configure_header = _gz_configure_header
 gz_configure_file = _gz_configure_header
 gz_export_header = _gz_export_header
+gz_include_header = _gz_include_header

--- a/gazebo/private/BUILD.bazel
+++ b/gazebo/private/BUILD.bazel
@@ -6,6 +6,7 @@ bzl_library(
     srcs = [
         "gz_configure_file.bzl",
         "gz_export_header.bzl",
+        "gz_include_header.bzl",
     ],
 )
 

--- a/gazebo/private/gz_include_header.bzl
+++ b/gazebo/private/gz_include_header.bzl
@@ -1,0 +1,38 @@
+"""Generate a header that includes a set of other headers.
+This creates a rule to generate a header that includes a list of other headers.
+The generated file will be of the form:
+    #include <hdr>
+    #include <hdr>
+The included `hdr` path is deduced by extracting the path from the input header
+path after `**/include/`. Any header path which does not match this pattern is
+ignored.
+Args:
+    hdrs (:obj:`str`): List of files or file labels of headers that the
+        generated header will include.
+"""
+
+# Generate a header that includes a set of other headers
+def _generate_include_header_impl(ctx):
+    # Collect list of headers
+    hdrs = []
+    for h in ctx.attr.hdrs:
+        for f in h.files.to_list():
+            parts = f.short_path.split("include/")
+            if len(parts) > 1:
+                # Append everything after the first match if non-empty
+                hdr = "".join(parts[1:])
+                if hdr:
+                    hdrs.append(hdr)
+
+    # Generate include header
+    content = "#pragma once\n"
+    content = content + "\n".join(["#include <%s>" % h for h in hdrs])
+    ctx.actions.write(output = ctx.outputs.out, content = content)
+
+gz_include_header = rule(
+    attrs = {
+        "hdrs": attr.label_list(allow_files = True),
+        "out": attr.output(mandatory = True),
+    },
+    implementation = _generate_include_header_impl,
+)


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds a `gz_include_header` rule to create a header file that includes a set of provided headers. This is functionally similar to the identically named rule in [gz_bazel](https://github.com/gazebosim/gz-bazel/blob/garden/skylark/gz_include_header.bzl) but the implementation is much simpler (sufficient for all gz use cases).

## Test it
Manually tested by adding local path override in [sdformat on this branch](https://github.com/gazebosim/sdformat/tree/shameek/sdf_hh).

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.