### PR TITLE
chore(ci): fix invalid JSON syntax in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
       folders: |
         [
           ".",
-          "test/smoke",
+          "test/smoke"
         ]
       exclude: |
         [
           {"folder": ".", "bzlmodEnabled": false},
-          {"folder": "test/smoke", "bzlmodEnabled": false},
+          {"folder": "test/smoke", "bzlmodEnabled": false}
         ]


### PR DESCRIPTION
This PR fixes trailing commas in the ci.yml file which were causing jq to fail during the matrix-prep-exclude step in GitHub Actions. This should unblock the Renovate PRs.